### PR TITLE
Case Insensitivity on Permissions

### DIFF
--- a/client/js/controllers/application/applicationViewController.js
+++ b/client/js/controllers/application/applicationViewController.js
@@ -6,7 +6,7 @@ featureToggleFrontend.controller('ApplicationViewController', ['$scope', '$route
     $scope.userHasPermissionsLoaded = false; // stops flickering of alert and buttons
 
     if ($scope.requiresAuthentication) {
-        authorisationService.isUserAuthorised($scope.applicationName, CurrentUser.email, function (err, isAuthorised) {
+        authorisationService.isUserAuthorised($scope.applicationName, CurrentUser.getEmail(), function (err, isAuthorised) {
             $scope.userHasPermissions = !err && isAuthorised;
             $scope.userHasPermissionsLoaded = true;
         });

--- a/client/js/domain/user.js
+++ b/client/js/domain/user.js
@@ -33,20 +33,24 @@ angular.module('featureToggleFrontend')
           },
 
           getUser: function () {
-                return this;
-            },
+              return this;
+          },
 
-            getFullName: function () {
-                if (!ENV.RequiresAuth) {
-                  return 'Anonymous';
-                }
+          getEmail: function() {
+            return this.email.toLowerCase();
+          },
 
-                return this.name.givenName + ' ' + this.name.familyName;
-            },
+          getFullName: function () {
+              if (!ENV.RequiresAuth) {
+                return 'Anonymous';
+              }
 
-            requiresAuthentication: function () {
-                return ENV.RequiresAuth;
-            }
+              return this.name.givenName + ' ' + this.name.familyName;
+          },
+
+          requiresAuthentication: function () {
+              return ENV.RequiresAuth;
+          }
 
         };
 

--- a/client/views/partials/userProfile.jade
+++ b/client/views/partials/userProfile.jade
@@ -7,4 +7,4 @@ h1.content-heading User Profile
       br
       br
       strong Email:
-      input(type="text" class="fullwidth" readonly="readonly" value="{{currentUser.email}}")
+      input(type="text" class="fullwidth" readonly="readonly" value="{{currentUser.getEmail()}}")

--- a/server/acl.js
+++ b/server/acl.js
@@ -7,14 +7,14 @@ var EtcdAclStore = function () {
 };
 
 EtcdAclStore.prototype.grant = function (userEmail, resource, callback) {
-    etcd.client.set('v1/toggleAcl/' + resource + '/' + userEmail, userEmail, function (err) {
+    etcd.client.set('v1/toggleAcl/' + resource + '/' + userEmail.toLowerCase(), userEmail.toLowerCase(), function (err) {
         if (err) callback(err);
         callback();
     });
 };
 
 EtcdAclStore.prototype.assert = function (userEmail, resource, callback) {
-    etcd.client.get('v1/toggleAcl/' + resource + '/' + userEmail, function (err) {
+    etcd.client.get('v1/toggleAcl/' + resource + '/' + userEmail.toLowerCase(), function (err) {
         if (err) {
             if (err.errorCode === 100) { // key not found
                 callback(null, false);
@@ -28,7 +28,7 @@ EtcdAclStore.prototype.assert = function (userEmail, resource, callback) {
 };
 
 EtcdAclStore.prototype.revoke = function (userEmail, resource, callback) {
-    etcd.client.delete('v1/toggleAcl/' + resource + '/' + userEmail, function (err) {
+    etcd.client.delete('v1/toggleAcl/' + resource + '/' + userEmail.toLowerCase(), function (err) {
         if (err) {
             if (err.errorCode === 100) { // key not found
                 callback();

--- a/server/app.js
+++ b/server/app.js
@@ -74,8 +74,8 @@ var authoriseUserForThisApplication = function (req, res, next) {
     var applicationName = req.params.applicationName;
     var userEmail = req.user._json.email;
 
-    acl.assert(userEmail, applicationName, function (err, isAuthroised) {
-        if (err || !isAuthroised) {
+    acl.assert(userEmail, applicationName, function (err, isAuthorised) {
+        if (err || !isAuthorised) {
             res.send(403);
         } else {
             next();

--- a/server/domain/application.js
+++ b/server/domain/application.js
@@ -45,7 +45,7 @@ module.exports = {
 
             // todo: not sure if this is correct
             if (config.RequiresAuth) {
-                var userEmail = getUserDetails(req).email; // todo: need better user management
+                var userEmail = getUserDetails(req).getEmail(); // todo: need better user management
                 acl.grant(userEmail, applicationName, function (grantErr) {
                     if (grantErr) {
                         cb(grantErr);


### PR DESCRIPTION
Lowercased all of the email addresses, so that permissions are now case insensitive

(For instance where some users are created as Some.User, some as some.user - it's simpler for consistency for everything to be lowercased)
