### PR TITLE
should pass the toggle value to the hooks rather than 'false'

### DIFF
--- a/server/domain/feature.js
+++ b/server/domain/feature.js
@@ -329,7 +329,7 @@ module.exports.updateFeatureToggle = function (applicationName, featureName, val
           applicationName: applicationName,
           featureName: featureName,
           toggleName: null,
-          value: false
+          value: value
         });
 
         cb();


### PR DESCRIPTION
needed to fix the audit bugs
